### PR TITLE
Improve java analyzer tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,19 +17,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <version>5.4.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/javabycomparison/kata/analysis/JavaAnalyzerTests.java
+++ b/src/test/java/com/javabycomparison/kata/analysis/JavaAnalyzerTests.java
@@ -15,6 +15,7 @@ class JavaAnalyzerTests {
   @Test
   void analyze() throws IOException {
     JavaAnalyzer javaAnalyzer = new JavaAnalyzer(null);
+
     assertNotNull(javaAnalyzer);
     assertNull(javaAnalyzer.analyze());
   }
@@ -28,8 +29,11 @@ class JavaAnalyzerTests {
 
   @Test
   void analyzeJavaFizzBuzz() throws IOException {
-    Assertions.assertEquals(
-        new ResultData(0, "./src/main/resources/java_files/FizzBuzz.java", 15, 4, 0, 0),
-        new JavaAnalyzer(Paths.get("./src/main/resources/java_files/FizzBuzz.java")).analyze());
+      JavaAnalyzer javaAnalyzer = new JavaAnalyzer(Paths.get("./src/main/resources/java_files/FizzBuzz.java"));
+
+      ResultData analyze = javaAnalyzer.analyze();
+
+      ResultData expected = new ResultData(0, "./src/main/resources/java_files/FizzBuzz.java", 15, 4, 0, 0);
+      Assertions.assertEquals(expected, analyze);
   }
 }

--- a/src/test/java/com/javabycomparison/kata/analysis/JavaAnalyzerTests.java
+++ b/src/test/java/com/javabycomparison/kata/analysis/JavaAnalyzerTests.java
@@ -1,12 +1,14 @@
 package com.javabycomparison.kata.analysis;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JavaAnalyzerTests {
 
@@ -20,11 +22,8 @@ class JavaAnalyzerTests {
   @Test
   void analyzeShouldThrowIOException() {
     JavaAnalyzer javaAnalyzer = new JavaAnalyzer(Paths.get("./XXX_unavailable_directory/"));
-    try {
-      javaAnalyzer.analyze();
-    } catch (IOException ioe) {
 
-    }
+    assertThrows(IOException.class, javaAnalyzer::analyze);
   }
 
   @Test


### PR DESCRIPTION
Hello,

I noticed that one of the JavaAnalyzerTests could be improved. When testing that an exception is thrown, the try&catch construct I know/teach looks slightly different:

```java
  @Test
  void analyzeShouldThrowIOException() {
    JavaAnalyzer javaAnalyzer = new JavaAnalyzer(Paths.get("./XXX_unavailable_directory/"));
    try {
      javaAnalyzer.analyze();
      fail("should have thrown IOException");
    } catch (IOException ioe) {

    }
  }
```

Without the fail(), the test still passes when no exception is thrown. Can be observed by changing JavaAnalyzer line 40 to "return null;", the test would still pass.

Since this project uses junit5, I then went with their assertThrows method to test it, as it produces a good error message out of the box (instead of writing a message in the fail call like i showed above).

In my last commit I tried to improve readability, I simply added some empty lines to give the tests a structure and extracted variables to make the call to assertEquals more clear.